### PR TITLE
Log: Fix loglevel overwritten problem

### DIFF
--- a/include/StdLog.h
+++ b/include/StdLog.h
@@ -42,19 +42,17 @@ public:
 		std::string message;
 
 		// [Date Time][PID/TID][filename][function:line] message
-		message += COLOR_STR[level];
 		message += currentDateTime();
 		message += stringFormat("[%d/%d]", getpid(), gettid());
-		message += stringFormat("[%s]", LOG_LEVEL_STR[level].c_str());
+		message += stringFormat("[%s]", LOG_LEVEL_STR[level]);
 		if (file)
 			message += stringFormat("[%s][%s:%d]", (std::strrchr(file, '/') ? std::strrchr(file, '/') + 1 : file), caller, line);
 		else
 			message += stringFormat("[%s][%s:%d]", file, caller, line);
 		message += " ";
 		message += stringFormat(format, args ... );
-		message += COLOR_STR[0]; // reset color
 
-		std::cout << message << std::endl;
+		std::cout << COLOR_STR[level] << message << COLOR_STR[0] << std::endl;
 	}
 
 private:
@@ -84,7 +82,7 @@ private:
 		return buf;
 	}
 
-	const std::vector<std::string> LOG_LEVEL_STR = {
+	const std::vector<const char*> LOG_LEVEL_STR = {
 		"none",
 		"D", // debug
 		"I", // info

--- a/src/Log.cpp
+++ b/src/Log.cpp
@@ -20,29 +20,33 @@
 
 using namespace ovi;
 
-constexpr int DEFAULT_LOG_LEVEL = 0;
-
 namespace ovi::logger {
+constexpr int DEFAULT_LOG_LEVEL = LOG_LEVEL_ALL;
+
+static bool initialized = false;
 static LogLevel logLevel = LOG_LEVEL_OFF;
 }
 
 void logger::init(void)
 {
-	logger::init(Configuration::instance().get(CATEGORY_CORE, CORE_LOG_LEVEL, DEFAULT_LOG_LEVEL));
+	init(Configuration::instance().get(CATEGORY_CORE, CORE_LOG_LEVEL, DEFAULT_LOG_LEVEL));
 }
 
 void logger::init(int level)
 {
-	logger::logLevel = static_cast<LogLevel>(level);
+	if (initialized)
+		return;
+	logLevel = static_cast<LogLevel>(level);
+	initialized = true;
 }
 
 void logger::init(const std::string& path)
 {
 	// TODO: implement
-	logger::init(LOG_LEVEL_OFF);
+	init(LOG_LEVEL_OFF);
 }
 
 bool logger::validateLogLevel(LogLevel level)
 {
-	return (logger::logLevel > level);
+	return (logLevel > level);
 }


### PR DESCRIPTION
Even if application or tools change the loglevel, it has been overwritten by ovi_session_create().
Since the log level can be changed at launching, it has been modified so that it can be set only once through adding the initialization variable.