### PR TITLE
Build: Add missing header

### DIFF
--- a/include/Callback.h
+++ b/include/Callback.h
@@ -17,6 +17,7 @@
 #ifndef __OPEN_VIDEO_INTELLIGENCE_CALLBACK_H__
 #define __OPEN_VIDEO_INTELLIGENCE_CALLBACK_H__
 
+#include <string>
 #include <variant>
 #include <memory>
 


### PR DESCRIPTION
Fix build error on ubuntu 22.04 due to gcc-11

https://gcc.gnu.org/gcc-11/porting_to.html
Header dependency changes
Some C++ Standard Library headers have been changed to no longer include other headers that were being used internally by the library. As such, C++ programs that used standard library components without including the right headers will no longer compile.